### PR TITLE
update play.goplus.org, change "star" button url.

### DIFF
--- a/playground/edit.html
+++ b/playground/edit.html
@@ -132,7 +132,7 @@
         <option value="listmap.txt">List/Map comprehension</option>
         <option value="error.txt">Error wrap</option>
     </select>
-    <iframe id="iframe" src="https://ghbtns.com/github-btn.html?user=qiniu&repo=goplus&type=star&count=true&size=large"
+    <iframe id="iframe" src="https://ghbtns.com/github-btn.html?user=goplus&repo=gop&type=star&count=true&size=large"
             frameborder="0" scrolling="0" class="github-stars"></iframe>
 
     <input type="button" value="About" id="aboutButton">
@@ -162,7 +162,7 @@
             <p>GoPlus - The Go+ language for data science. All components are available under the <a
                         href="https://www.apache.org/licenses/LICENSE-2.0">Apache 2 License</a> on <a
                         href="https://github.com/qiniu/goplus">GitHub</a>.</p>
-            <iframe src="https://ghbtns.com/github-btn.html?user=qiniu&repo=goplus&type=star&count=true&size=large"
+            <iframe src="https://ghbtns.com/github-btn.html?user=goplus&repo=gop&type=star&count=true&size=large"
                     frameborder="0" scrolling="0" class="github-stars"></iframe>
         </div>
     </div>


### PR DESCRIPTION
update play.goplus.org, change "star" button url.

修复“star”按钮的链接，原来的链接是链接到 qiniu/goplus