### PR TITLE
move from qgo to gop to fit goplus v0.9.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/aws/aws-sdk-go v1.32.5
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/google/go-cmp v0.5.0
-	github.com/qiniu/goplus v0.6.41-0.20200627014401-a031ebddfa3f
+	github.com/goplus/gop v0.9.6
 	github.com/shurcooL/webdavfs v0.0.0-20190527155401-0680c3c63e3c
 	go.opencensus.io v0.22.4
 	golang.org/x/build v0.0.0-20200618235529-3228d3c70d31
-	golang.org/x/mod v0.3.0
+	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20200602114024-627f9648deb9
-	golang.org/x/tools v0.0.0-20200619180055-7c47624df98f
+	golang.org/x/tools v0.1.5
 	google.golang.org/api v0.28.0
 	google.golang.org/genproto v0.0.0-20200619004808-3e7fca5c55db
 	google.golang.org/grpc v1.39.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	golang.org/x/tools v0.0.0-20200619180055-7c47624df98f
 	google.golang.org/api v0.28.0
 	google.golang.org/genproto v0.0.0-20200619004808-3e7fca5c55db
+	google.golang.org/grpc v1.39.0 // indirect
 	grpc.go4.org v0.0.0-20170609214715-11d0a25b4919
 )
 

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,9 @@ github.com/google/pprof v0.0.0-20200507031123-427632fa3b1c/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/goplus/gop v0.9.6 h1:ny5L1VZ3Y2rahB/bUw+C0ahXNnlU+33ChZUuzXX3q78=
+github.com/goplus/gop v0.9.6/go.mod h1:wbUYHG7OCPa7TvI8DsgzJviR1CWKlPHNSKeVPdVSRMc=
+github.com/goplus/gox v0.9.23/go.mod h1:jRTG/pYm6zzVme7kWEEZQ8Ah2W4gyFID+YZHqVTCdxc=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -118,6 +121,8 @@ github.com/qiniu/goplus v0.6.41-0.20200627014401-a031ebddfa3f h1:60UriceFM7qBZv6
 github.com/qiniu/goplus v0.6.41-0.20200627014401-a031ebddfa3f/go.mod h1:p/bMvJU8jV85hla2KKlDBy9dMqSMGdm88MTqz25HMm0=
 github.com/qiniu/x v1.10.5 h1:7V/CYWEmo9axJULvrJN6sMYh2FdY+esN5h8jwDkA4b0=
 github.com/qiniu/x v1.10.5/go.mod h1:03Ni9tj+N2h2aKnAz+6N0Xfl8FwMEDRC2PAlxekASDs=
+github.com/qiniu/x v1.11.5 h1:TYr5cl4g2yoHAZeDK4MTjKF6CMoG+IHlCDvvM5qym6U=
+github.com/qiniu/x v1.11.5/go.mod h1:03Ni9tj+N2h2aKnAz+6N0Xfl8FwMEDRC2PAlxekASDs=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/shurcooL/webdavfs v0.0.0-20190527155401-0680c3c63e3c h1:hrFjpFFCbJL/sC7LNMzIKtgwZCTETOxQPko1UeoPa4c=
 github.com/shurcooL/webdavfs v0.0.0-20190527155401-0680c3c63e3c/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20200523222454-059865788121 h1:rITEj+UZHYC927n8GT97eC3zrpzXdb/voyeOuVKS46o=
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/goplus.org/index.html
+++ b/goplus.org/index.html
@@ -111,43 +111,8 @@ fmt.Println(<span style="color: #aa5500">&quot;x:&quot;</span>, x)
 </section>
 
 
+
 <section class="py-5 bg-light">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-6">
-                <h2 class="pb-3">Rational number: bigint, bigrat, bigfloat</h2>
-                <P>We introduce the rational number as native Go+ types. We use suffix r to denote rational literals.
-                    For example, (1r << 200) means a big int whose value is equal to 2<sup>200</sup>. And 4/5r means the
-                    rational
-                    constant 4/5.</P>
-                <a href="https://play.goplus.org/p/bRwN15drYVP">
-                    <button type="btn" class="btn btn-info ">Go to Playground</button>
-                </a>
-
-            </div>
-            <div class="col-md-6">
-
-                <!-- HTML generated using hilite.me -->
-                <div style="background: #ffffff; overflow:auto;width:auto;border:solid gray;border-width:.1em .1em .1em .8em;padding:.2em .6em;"><pre
-                            style="margin: 0; line-height: 125%">a := <span
-                                style="color: #009999">1</span>r &lt;&lt; <span style="color: #009999">65</span>   <span
-                                style="color: #aaaaaa; font-style: italic">// bigint, large than int64</span>
-b := <span style="color: #009999">4</span>/<span style="color: #009999">5</span>r       <span
-                                style="color: #aaaaaa; font-style: italic">// bigrat</span>
-c := b - <span style="color: #009999">1</span>/<span style="color: #009999">3</span>r + <span
-                                style="color: #009999">3</span> * <span style="color: #009999">1</span>/<span
-                                style="color: #009999">2</span>r
-<span style="color: #00aaaa">println</span>(a, b, c)
-</pre>
-                </div>
-
-            </div>
-        </div>
-    </div>
-</section>
-
-
-<section class="py-5 bg-white">
     <div class="container">
         <div class="row">
             <div class="col-md-6">
@@ -181,7 +146,7 @@ resultArray := [[a, b] <span style="color: #0000aa">for</span> a &lt;- array, a 
 </section>
 
 
-<section class="py-5 bg-light">
+<section class="py-5 bg-white">
     <div class="container">
         <div class="row">
             <div class="col-md-6">
@@ -205,7 +170,7 @@ expr?:defval <span style="color: #aaaaaa; font-style: italic">// use defval if e
     </div>
 </section>
 
-<section class="py-5 bg-white">
+<section class="py-5 bg-light">
     <div class="container">
         <div class="row">
             <div class="col-md-6">
@@ -227,10 +192,10 @@ println(<span style="color: #aa5500">&quot;Hello, Go+&quot;</span>)
 </section>
 
 
-<div class="copyright bg-light border pt-2">
+<div class="copyright bg-white border pt-2">
     <div class="container">
         <div class="row justify-content-md-center">
-            <p> Github:https://github.com/goplus/gop. Powered By Qiniu.com. </p>
+            <p> Github:<a href="https://github.com/goplus/gop">https://github.com/goplus/gop</a>. Powered By Qiniu.com. </p>
         </div>
     </div>
 </div>

--- a/playground/edit.go
+++ b/playground/edit.go
@@ -90,9 +90,6 @@ func (s *server) handleEdit(w http.ResponseWriter, r *http.Request) {
 
 const hello = `println("Hello, Go+")
 
-println(1r << 129)
-println(1/3r + 2/7r*2)
-
 arr := [1, 3, 5, 7, 11, 13, 17, 19]
 println(arr)
 println([x*x for x <- arr, x > 3])

--- a/playground/examples/hello.txt
+++ b/playground/examples/hello.txt
@@ -1,8 +1,5 @@
 println("Hello, Go+")
 
-println(1r << 129)
-println(1/3r + 2/7r*2)
-
 arr := [1, 3, 5, 7, 11, 13, 17, 19]
 println(arr)
 println([x*x for x <- arr, x > 3])

--- a/playground/fmt.go
+++ b/playground/fmt.go
@@ -7,7 +7,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qiniu/goplus/format"
+	"github.com/goplus/gop/format"
 	"net/http"
 	"path"
 

--- a/playground/fmt_test.go
+++ b/playground/fmt_test.go
@@ -29,11 +29,8 @@ func TestHandleFmt(t *testing.T) {
 		{
 			name:   "goplus hello world",
 			method: http.MethodPost,
-			body:   `println("Hello, Go+")
+			body: `println("Hello, Go+")
 
-
-println(1r << 129  )
-println(1/3r + 2/7r * 2)
 
 arr := [1, 3, 5, 7, 11,  13, 17, 19]
  println(arr)
@@ -44,10 +41,7 @@ println(m)
 println({v:  k for k  , v <- m})
 println([k for k, _ <-  m])
 println( [ v for v <- m]  )`,
-			want:   `println("Hello, Go+")
-
-println(1r << 129)
-println(1/3r + 2/7r*2)
+			want: `println("Hello, Go+")
 
 arr := [1, 3, 5, 7, 11, 13, 17, 19]
 println(arr)

--- a/playground/goplus.go
+++ b/playground/goplus.go
@@ -5,13 +5,12 @@ package main
 import (
 	"log"
 
-	"github.com/qiniu/goplus/ast"
-	"github.com/qiniu/goplus/cl"
-	exec "github.com/qiniu/goplus/exec/bytecode"
-	"github.com/qiniu/goplus/parser"
-	"github.com/qiniu/goplus/token"
+	"github.com/goplus/gop/ast"
+	"github.com/goplus/gop/cl"
+	exec "github.com/goplus/gop/exec/bytecode"
+	"github.com/goplus/gop/parser"
+	"github.com/goplus/gop/token"
 
-	_ "github.com/qiniu/goplus/lib"
 )
 
 func buildGoplus(data string) {

--- a/playground/sandbox.go
+++ b/playground/sandbox.go
@@ -447,11 +447,11 @@ func sandboxBuildGoplus(ctx context.Context, tmpDir string, in []byte, vet bool)
 
 	br := new(buildResult)
 
-	qgo, err := exec.LookPath("qgo")
+	qgo, err := exec.LookPath("gop")
 	if err != nil {
 		return nil, fmt.Errorf("error find qgo command: %v", err)
 	}
-	cmdGenerate := exec.Command(qgo, ".")
+	cmdGenerate := exec.Command(qgo, "go", ".")
 	cmdGenerate.Dir = tmpDir
 
 	out := &bytes.Buffer{}
@@ -463,13 +463,12 @@ func sandboxBuildGoplus(ctx context.Context, tmpDir string, in []byte, vet bool)
 		}
 		if _, ok := err.(*exec.ExitError); ok {
 			br.errorMessage = br.errorMessage + strings.Replace(string(out.Bytes()), tmpDir+"/", "", -1)
-			br.errorMessage = strings.Replace(br.errorMessage, "# command-line-arguments\n", "", 1)
 			return br, nil
 		}
 	}
 
 	// until now, qgo does not provide process exit code, so we hard code this.
-	if strings.Contains(out.String(), "[ERROR]") {
+	if strings.Contains(out.String(), "errors") || strings.Contains(out.String(), "TODO") {
 		br.errorMessage = br.errorMessage + strings.Replace(string(out.Bytes()), tmpDir+"/", "", -1)
 		br.errorMessage = strings.Replace(br.errorMessage, "# command-line-arguments\n", "", 1)
 		return br, nil


### PR DESCRIPTION
Main modifications:
1. change qgo to `gop go dir`
2. remove rational constant support.

由qgo更新到gop。

主要修改：

1. qgo更改到gop go dir
2. 删除复数支持。