### PR TITLE
replace Download Go+ with Install Go+

### DIFF
--- a/goplus.org/components/Home/Intro/index.tsx
+++ b/goplus.org/components/Home/Intro/index.tsx
@@ -14,12 +14,12 @@ export default function Intro() {
           <a href="https://play.goplus.org" className={styles.primaryBtn} rel="noopener">
             Try Go+
           </a>
-          <a href="https://github.com/goplus/gop/releases" className={styles.btn} rel="noopener">
-            <Image width={24} height={16} src="/download.svg" alt="Download Logo" />
-            <span className={styles.downloadTxt}>Download Go+</span>
+          <a href="https://github.com/goplus/gop#how-to-install" className={styles.btn} rel="noopener">
+            <Image width={24} height={16} src="/download.svg" alt="Download Icon" />
+            <span className={styles.installTxt}>Install Go+</span>
           </a>
         </div>
-        <Image width={172} height={133} src="/qiniu_doll.png" alt="Qiniu Doll Logo" />
+        <Image width={172} height={133} src="/qiniu_doll.png" alt="Qiniu Doll" />
       </div>
     </div>
   )

--- a/goplus.org/components/Home/Intro/style.module.css
+++ b/goplus.org/components/Home/Intro/style.module.css
@@ -49,7 +49,7 @@
   background-color: #FAFAFA;
 }
 
-.downloadTxt {
+.installTxt {
   margin-left: 20px;
 }
 


### PR DESCRIPTION
> ## How to install
> 
> For now, we suggest you install Go+ from source code.

For now, installing instead of downloading is prefered. We link "Install Go+" to the "How to install" section of goplus/gop README to avoid duplicate install info. 