### PR TITLE
fix gop module build

### DIFF
--- a/playground/sandbox/sandbox.go
+++ b/playground/sandbox/sandbox.go
@@ -199,7 +199,7 @@ func listDockerContainers(ctx context.Context) ([]dockerContainer, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("listDockerContainers: cmd.Start() failed: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	if err := internal.WaitOrStop(ctx, cmd, os.Interrupt, 250*time.Millisecond); err != nil {
 		return nil, fmt.Errorf("listDockerContainers: internal.WaitOrStop() failed: %w", err)

--- a/playground/sandbox/sandbox.go
+++ b/playground/sandbox/sandbox.go
@@ -199,7 +199,7 @@ func listDockerContainers(ctx context.Context) ([]dockerContainer, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("listDockerContainers: cmd.Start() failed: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	if err := internal.WaitOrStop(ctx, cmd, os.Interrupt, 250*time.Millisecond); err != nil {
 		return nil, fmt.Errorf("listDockerContainers: internal.WaitOrStop() failed: %w", err)


### PR DESCRIPTION
1. change build from `gop, "go", "."`  to `qgo, "build", "-o", "a.out", "-tags=faketime", "."`
2. remove the origin build method `"go", "build", "-o", "a.out", "-tags=faketime", "gop_autogen.go"`

the testing environment is : https://goplay.qiniu.com/

the vercel bot is goplus.org, not playground.