### PR TITLE
change format to goplus xformat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/aws/aws-sdk-go v1.37.0
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
 	github.com/google/go-cmp v0.5.5
-	github.com/goplus/gop v1.0.15
+	github.com/goplus/gop v1.0.33-0.20211204062201-15116b6ffecc
 	github.com/shurcooL/webdavfs v0.0.0-20190527155401-0680c3c63e3c
 	go.opencensus.io v0.23.0
 	golang.org/x/mod v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -119,9 +119,9 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/goplus/gop v1.0.15 h1:ylVDIPyYa9Fzvp8LeHzR8zz0iWuGBLGuK3/HRBUS+LM=
-github.com/goplus/gop v1.0.15/go.mod h1:oo5V2tps5zZxzPXqnO1ENeXOVBIjQnMRI8ZIRCQ72rk=
-github.com/goplus/gox v1.7.10/go.mod h1:orZ6Mr9qqB4BVaVCMp/cypMtkn0Fp5XUE7e5uqjZATA=
+github.com/goplus/gop v1.0.33-0.20211204062201-15116b6ffecc h1:GnNOSwWAEcj/VCPyh/aH9OIKrA9Z6VSbUMRdm8nr/Y0=
+github.com/goplus/gop v1.0.33-0.20211204062201-15116b6ffecc/go.mod h1:zbsPaUDiA9eo7C72X+Oj1kq6S7YiMHwMr/wPvyxrGQ4=
+github.com/goplus/gox v1.8.0/go.mod h1:fUMG5YrEvPjSfGqPnP1gfrZvWlVuA1/9lZy3s/5+Aes=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/playground/fmt.go
+++ b/playground/fmt.go
@@ -7,10 +7,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/goplus/gop/format"
 	"net/http"
 	"path"
 
+	xformat "github.com/goplus/gop/x/format"
 	"golang.org/x/mod/modfile"
 	"golang.org/x/tools/imports"
 )
@@ -46,7 +46,7 @@ func handleFmt(w http.ResponseWriter, r *http.Request) {
 				// can find symbols in sibling files.
 				out, err = imports.Process(f, in, nil)
 			} else {
-				out, err = format.Source(in)
+				out, err = xformat.GopstyleSource(in)
 			}
 			if err != nil {
 				errMsg := err.Error()


### PR DESCRIPTION
format or xformat would auto implement a filename `prog.go` here, so we do not need to call `xformat.GopstyleSource(source, fileName)`
```
				out, err = xformat.GopstyleSource(in)
```