### PR TITLE
fix "Pop-up window blocked" for code edit-button

### DIFF
--- a/goplus.org/components/Code/index.tsx
+++ b/goplus.org/components/Code/index.tsx
@@ -221,28 +221,29 @@ function RunButton({ code, onResult }: RunButtonProps) {
 }
 
 function EditButton({ code }: { code: string }) {
-  const [loading, setLoading] = useState(false)
+  const [url, setUrl] = useState<string | null>(null)
+
+  // Request playground url aftered rendered,
+  // instead of after clicked (which may causes Pop-up window blocked)
+  useEffect(() => {
+    share(code).then(setUrl)
+    // TODO: deal with error
+  }, [code])
 
   async function handleClick() {
-    let url: string
-    setLoading(true)
-    try {
-      url = await share(code)
-    } catch (e: unknown) {
-      // TODO: deal with error
-      return
-    } finally {
-      setLoading(false)
-    }
+    if (url == null) return
     window.open(url, 'goplus-playground')
   }
 
+  const urlReady = url != null
+  const title = (
+    urlReady
+    ? 'Edit Code In Playground'
+    : 'Fetching Playground URL...'
+  )
+
   return (
-    <Button
-      title="Edit Code In Playground"
-      onClick={handleClick}
-      loading={loading}
-    >
+    <Button title={title} onClick={handleClick} disabled={!urlReady}>
       <IconEdit />
     </Button>
   )

--- a/goplus.org/components/Code/style.module.scss
+++ b/goplus.org/components/Code/style.module.scss
@@ -136,11 +136,15 @@
   border-radius: 4px;
   transition: all .2s;
 
-  &:hover {
+  &:disabled {
+    cursor: not-allowed;
+  }
+
+  &:hover:not(:disabled) {
     background-color: #F5F5F5;
   }
 
-  &:active {
+  &:active:not(:disabled) {
     background-color: #F0F0F0;
   }
 


### PR DESCRIPTION
fix #42 

Pop-up window blocked under safari / firefox, cuz we do `window.open` after a async fetch behavior (for playground URL).