### PR TITLE
fix gop build output

### DIFF
--- a/playground/sandbox.go
+++ b/playground/sandbox.go
@@ -498,7 +498,7 @@ func sandboxBuildGoplus(ctx context.Context, tmpDir string, in []byte, vet bool)
 func trimGopBuild(output string) string {
 	var res []string
 	for _, v := range strings.Split(output, "\n") {
-		if strings.Contains(v, "prog.gop") {
+		if !strings.Contains(v, "GenGo") && strings.TrimSpace(v) != "" {
 			//here we hard code the "./prog.gop" to prog.go, the frontend need this variable
 			//TODO: move frontend variable prog.go to prog.gop
 			res = append(res, strings.Replace(v, "./prog.gop", "prog.go", -1))


### PR DESCRIPTION
fix the output trim error:
some gop build result does not have a file name and a line number, such as: `-: cannot use  (type []int) as type []interface{} in assignment`


before:

![image](https://user-images.githubusercontent.com/2325492/146302457-aa6bb128-e42d-4ece-b851-5987550eb43e.png)


after:

![image](https://user-images.githubusercontent.com/2325492/146302547-2dfd336b-1ff9-4a86-add7-7491d2d73ebf.png)
