### PR TITLE
add examples-select for Home Intro

### DIFF
--- a/goplus.org/components/Code/Block/index.tsx
+++ b/goplus.org/components/Code/Block/index.tsx
@@ -148,7 +148,7 @@ function RunButton({ code, onResult }: RunButtonProps) {
   useEffect(() => onResultRef.current(result), [result])
 
   return (
-    <Button title="Run Code" onClick={run} loading={loading}>
+    <Button title="Run Code" onClick={() => run()} loading={loading}>
       <IconPlay />
     </Button>
   )

--- a/goplus.org/components/Code/Editor/index.tsx
+++ b/goplus.org/components/Code/Editor/index.tsx
@@ -3,7 +3,7 @@
  * @desc Edit & run gop code
  */
 
-import React, { useEffect, useRef, useState } from 'react'
+import React, { ReactNode, useEffect, useRef, useState } from 'react'
 import Editor, { EditorProps, Monaco } from '@monaco-editor/react'
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api'
 
@@ -47,6 +47,7 @@ const theme: editor.IStandaloneThemeData = {
 export interface Props {
   code: string
   runImmediately?: boolean
+  footerExtra?: ReactNode
   className?: string
   editorClassName?: string
 }
@@ -54,8 +55,9 @@ export interface Props {
 export default function CodeEditor({
   code: codeFromProps,
   runImmediately = false,
+  footerExtra,
   className,
-  editorClassName
+  editorClassName,
 }: Props) {
   const isMobile = useMobile()
   const [code, setCode] = useState(codeFromProps)
@@ -71,7 +73,7 @@ export default function CodeEditor({
 
   useEffect(() => {
     setCode(codeFromProps)
-    if (runImmediatelyRef.current) runRef.current()
+    if (runImmediatelyRef.current) runRef.current(codeFromProps)
   }, [codeFromProps])
 
   className = cns(
@@ -105,6 +107,7 @@ export default function CodeEditor({
       </div>
       <RunResult result={result} autoScroll={false} />
       <div className={styles.footer}>
+        <div className={styles.extra}>{footerExtra}</div>
         <Button loading={loadingResult} onClick={run}>Run</Button>
       </div>
     </div>

--- a/goplus.org/components/Code/Editor/index.tsx
+++ b/goplus.org/components/Code/Editor/index.tsx
@@ -57,7 +57,7 @@ export default function CodeEditor({
   runImmediately = false,
   footerExtra,
   className,
-  editorClassName,
+  editorClassName
 }: Props) {
   const isMobile = useMobile()
   const [code, setCode] = useState(codeFromProps)

--- a/goplus.org/components/Code/Editor/style.module.scss
+++ b/goplus.org/components/Code/Editor/style.module.scss
@@ -44,5 +44,5 @@
 .footer {
   margin-top: 24px;
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 }

--- a/goplus.org/components/Code/Run/index.tsx
+++ b/goplus.org/components/Code/Run/index.tsx
@@ -60,12 +60,12 @@ export function useCodeRun(code: string) {
     setResult(result)
   }
 
-  const run = useCallback(async (codeToRun: string = code) => {
+  const run = useCallback(async (currentCode: string = code) => {
     startWaiting()
 
     let result: CompileResult
     try {
-      result = await compile({ body: codeToRun })
+      result = await compile({ body: currentCode })
     } catch (e: unknown) {
       const message = `Request failed: ${e && (e as any).message || 'Unkown'}`
       endWaiting(<Error>{message}</Error>)

--- a/goplus.org/components/Code/Run/index.tsx
+++ b/goplus.org/components/Code/Run/index.tsx
@@ -60,12 +60,12 @@ export function useCodeRun(code: string) {
     setResult(result)
   }
 
-  const run = useCallback(async () => {
+  const run = useCallback(async (codeToRun: string = code) => {
     startWaiting()
 
     let result: CompileResult
     try {
-      result = await compile({ body: code })
+      result = await compile({ body: codeToRun })
     } catch (e: unknown) {
       const message = `Request failed: ${e && (e as any).message || 'Unkown'}`
       endWaiting(<Error>{message}</Error>)

--- a/goplus.org/components/Home/Intro/examples.ts
+++ b/goplus.org/components/Home/Intro/examples.ts
@@ -1,0 +1,24 @@
+/**
+ * @file Examples for Intro
+ * @todo Use the same resource with `playground/examples/`
+ */
+
+import basic from './examples/basic.gop'
+import error from './examples/error.gop'
+import hello from './examples/hello.gop'
+import listmap from './examples/listmap.gop'
+import range from './examples/range.gop'
+import rational from './examples/rational.gop'
+import slice from './examples/slice.gop'
+
+const examples = [
+  { name: 'Hello, Go+', code: hello },
+  { name: 'Go+ Basic', code: basic },
+  { name: 'Error wrap', code: error },
+  { name: 'List/Map comprehension', code: listmap },
+  { name: 'Range', code: range },
+  { name: 'Rational', code: rational },
+  { name: 'Slice literal', code: slice }
+]
+
+export default examples

--- a/goplus.org/components/Home/Intro/examples/basic.gop
+++ b/goplus.org/components/Home/Intro/examples/basic.gop
@@ -1,0 +1,15 @@
+println "Hello, Go+"
+
+println 1r<<129
+println 1/3r+2/7r*2
+
+arr := [1, 3, 5, 7, 11, 13, 17, 19]
+println arr
+println [x*x for x <- arr, x > 3]
+
+m := {"Hi": 1, "Go+": 2}
+println m
+println {v: k for k, v <- m}
+println [k for k, _ <- m]
+println [v for v <- m]
+

--- a/goplus.org/components/Home/Intro/examples/error.gop
+++ b/goplus.org/components/Home/Intro/examples/error.gop
@@ -1,0 +1,26 @@
+import (
+	"strconv"
+)
+
+func add(x, y string) (int, error) {
+	return strconv.atoi(x)? + strconv.atoi(y)?, nil
+}
+
+func addSafe(x, y string) int {
+	return strconv.atoi(x)?:0 + strconv.atoi(y)?:0
+}
+
+// Error handling
+// We reinvent the error handling specification in Go+. We call them ErrWrap expressions:
+
+// expr! // panic if err
+// expr? // return if err
+// expr?:defval // use defval if err
+
+println `add("100", "23"):`, add("100", "23")!
+
+sum, err := add("10", "abc")
+println `add("10", "abc"):`, sum, err
+
+println `addSafe("10", "abc"):`, addSafe("10", "abc")
+

--- a/goplus.org/components/Home/Intro/examples/hello.gop
+++ b/goplus.org/components/Home/Intro/examples/hello.gop
@@ -1,0 +1,7 @@
+fields := [
+	"engineering",
+	"STEM education", 
+	"and data science",
+]
+
+println "The Go+ language for", fields.join(", ")

--- a/goplus.org/components/Home/Intro/examples/listmap.gop
+++ b/goplus.org/components/Home/Intro/examples/listmap.gop
@@ -1,0 +1,20 @@
+a := [x*x for x <- [1, 3, 5, 7, 11]]
+println a
+b := [x*x for x <- [1, 3, 5, 7, 11], x > 3]
+println b
+c := [i+v for i, v <- [1, 3, 5, 7, 11], i%2 == 1]
+println c
+d := [k+","+s for k, s <- {"Hello": "xsw", "Hi": "Go+"}]
+println d
+
+arr := [1, 2, 3, 4, 5, 6]
+e := [[a, b] for a <- arr, a < b for b <- arr, b > 2]
+println e
+
+x := {x: i for i, x <- [1, 3, 5, 7, 11]}
+println x
+y := {x: i for i, x <- [1, 3, 5, 7, 11], i%2 == 1}
+println y
+z := {v: k for k, v <- {1: "Hello", 3: "Hi", 5: "xsw", 7: "Go+"}, k > 3}
+println z
+

--- a/goplus.org/components/Home/Intro/examples/range.gop
+++ b/goplus.org/components/Home/Intro/examples/range.gop
@@ -1,0 +1,14 @@
+a := [1, 3, 5, 7, 11]
+b := [x*x for x <- a, x > 3]
+println b // output: [25 49 121]
+
+mapData := {"Hi": 1, "Hello": 2, "Go+": 3}
+reversedMap := {v: k for k, v <- mapData}
+println reversedMap // output: map[1:Hi 2:Hello 3:Go+]
+
+sum := 0
+for x <- [1, 3, 5, 7, 11, 13, 17], x > 3 {
+	sum += x
+}
+println sum
+

--- a/goplus.org/components/Home/Intro/examples/rational.gop
+++ b/goplus.org/components/Home/Intro/examples/rational.gop
@@ -1,0 +1,5 @@
+a := 1r << 65 // bigint, large than int64
+b := 4/5r     // bigrat
+c := b - 1/3r + 3*1/2r
+println a, b, c
+

--- a/goplus.org/components/Home/Intro/examples/slice.gop
+++ b/goplus.org/components/Home/Intro/examples/slice.gop
@@ -1,0 +1,30 @@
+// in Go we do:
+a := []float64{1, 2, 3.4}
+println a
+
+// in GoPlus we do:
+b := [1, 2, 3.4]
+println b
+
+//slice literal
+c := [1, 3.4] // []float64
+printf "%#v %T\n", c, c
+
+d := [1] // []int
+printf "%#v %T\n", d, d
+
+e := [1+2i, "xsw"] // []interface{}
+printf "%#v %T\n", e, e
+
+f := [1, 3.4, 3+4i] // []complex128
+printf "%#v %T\n", f, f
+
+g := [5+6i] // []complex128
+printf "%#v %T\n", g, g
+
+h := ["xsw", 3] // []interface{}
+printf "%#v %T\n", h, h
+
+empty := [] // []interface{}
+printf "%#v %T\n", empty, empty
+

--- a/goplus.org/components/Home/Intro/index.tsx
+++ b/goplus.org/components/Home/Intro/index.tsx
@@ -1,11 +1,10 @@
 import Logo from 'components/Icon/Logo'
 import CodeEditor from 'components/Code/Editor'
+
+import examples from './examples'
 import styles from './style.module.scss'
-
-const helloWorldCode = `// You can edit code here!
-// Click "Run" button and see the result
-
-println "Hello world"`
+import { useState } from 'react'
+import Select, { Option } from 'components/UI/Select'
 
 export default function Intro() {
 
@@ -22,13 +21,31 @@ export default function Intro() {
         </a>
       </div>
       <h2 className={styles.title}>Try Go+</h2>
-      <CodeEditor
-        className={styles.codeEditorWrapper}
-        editorClassName={styles.codeEditor}
-        code={helloWorldCode}
-        runImmediately
-      />
+      <CodeExamples />
     </div>
+  )
+}
+
+function CodeExamples() {
+  const [codeName, setCodeName] = useState(examples[0].name)
+  const code = examples.find(e => e.name === codeName)?.code ?? ''
+
+  const codeSelect = (
+    <Select value={codeName} onChange={setCodeName}>
+      {examples.map(({ name }) => (
+        <Option key={name} value={name}>{name}</Option>
+      ))}
+    </Select>
+  )
+
+  return (
+    <CodeEditor
+      className={styles.codeEditorWrapper}
+      editorClassName={styles.codeEditor}
+      code={code}
+      runImmediately
+      footerExtra={codeSelect}
+    />
   )
 }
 

--- a/goplus.org/components/Home/Intro/index.tsx
+++ b/goplus.org/components/Home/Intro/index.tsx
@@ -1,13 +1,13 @@
+import React, { useState } from 'react'
+
 import Logo from 'components/Icon/Logo'
 import CodeEditor from 'components/Code/Editor'
+import Select, { Option } from 'components/UI/Select'
 
 import examples from './examples'
 import styles from './style.module.scss'
-import { useState } from 'react'
-import Select, { Option } from 'components/UI/Select'
 
 export default function Intro() {
-
   return (
     <div className={styles.section}>
       <div className={styles.goPlus}>

--- a/goplus.org/components/UI/Button/style.module.scss
+++ b/goplus.org/components/UI/Button/style.module.scss
@@ -5,6 +5,7 @@
   padding: 0 16px;
   height: 32px;
 
+  cursor: pointer;
   font-size: 14px;
   border: none;
   border-radius: 2px;

--- a/goplus.org/components/UI/Select/arrow.svg
+++ b/goplus.org/components/UI/Select/arrow.svg
@@ -1,0 +1,3 @@
+<svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12.6569 6L7.00001 11.6569L1.34315 6" stroke="#BFBFBF"/>
+</svg>

--- a/goplus.org/components/UI/Select/index.tsx
+++ b/goplus.org/components/UI/Select/index.tsx
@@ -1,0 +1,37 @@
+import React, { ChangeEvent, ReactNode } from 'react'
+import { cns } from 'utils'
+
+import styles from './style.module.scss'
+
+interface Props {
+  children: ReactNode
+  value: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+export default function Select({ children, className, value, onChange }: Props) {
+
+  className = cns(styles.select, className)
+
+  function handleChange(e: ChangeEvent<HTMLSelectElement>) {
+    onChange(e.target.value)
+  }
+
+  return (
+    <div className={styles.selectWrapper}>
+      <select className={className} value={value} onChange={handleChange}>
+        {children}
+      </select>
+    </div>
+  )
+}
+
+export interface OptionProps {
+  value: string
+  children: string
+}
+
+export function Option(props: OptionProps) {
+  return <option {...props} />
+}

--- a/goplus.org/components/UI/Select/style.module.scss
+++ b/goplus.org/components/UI/Select/style.module.scss
@@ -1,0 +1,30 @@
+.selectWrapper {
+  position: relative;
+  &::after {
+    content: "";
+    position: absolute;
+    right: 12px;
+    top: 7px;
+    justify-self: end;
+    width: 14px;
+    height: 16px;
+    background-image: url(./arrow.svg);
+  }
+}
+
+.select {
+  display: flex;
+  align-items: center;
+  padding: 0 37px 0 11px;
+  width: 260px;
+  height: 32px;
+  position: relative;
+
+  appearance: none;
+  cursor: pointer;
+  font-size: 14px;
+  border: 1px solid #BFBFBF;
+  border-radius: 2px;
+  color: #333;
+  outline: none;
+}

--- a/goplus.org/next.config.js
+++ b/goplus.org/next.config.js
@@ -5,7 +5,7 @@ module.exports = {
 
   webpack: (config, options) => {
     config.module.rules.push({
-      test: /\.md/,
+      test: /\.(md|gop)$/,
       type: 'asset/source'
     })
 

--- a/goplus.org/types/index.d.ts
+++ b/goplus.org/types/index.d.ts
@@ -3,6 +3,11 @@ declare module '*.md' {
   export default content
 }
 
+declare module '*.gop' {
+  const content: string
+  export default content
+}
+
 declare module 'moveto' {
   export type Options = {
     duration?: number


### PR DESCRIPTION
### Examples Select

![image](https://user-images.githubusercontent.com/1492263/149942144-53739253-2215-43d0-8772-505b8a839511.png)

### To be done later

Currently the examples for goplus.org & play.goplus.org is maintained separately. We need to put them in one place. See #48.
