### PR TITLE
Make the generation of anchor IDs from title more compatible.

### DIFF
--- a/goplus.org/components/Home/Features/common.ts
+++ b/goplus.org/components/Home/Features/common.ts
@@ -2,6 +2,7 @@
 export function getAnchorId(title: string) {
   return title
     .split(/[^\w\d\s]/, 1)[0]
+    .trim()
     .split(/\s+/)
     .map(word => word.toLocaleLowerCase())
     .join('-')


### PR DESCRIPTION
Remove the "-" at the end of the anchor ID from title.

`Maybe it doesn't matter.`

![image](https://user-images.githubusercontent.com/73827386/170827665-331bb91c-17b1-49c8-ac06-2986d296ce63.png)
