### PR TITLE
Fix broken links in homepage (goplus.org)

### DIFF
--- a/goplus.org/components/Home/KeyFeatures/index.tsx
+++ b/goplus.org/components/Home/KeyFeatures/index.tsx
@@ -13,7 +13,7 @@ const content = `
 * The simplest engineering language that can be mastered by children (script-like style).
 * Performance: as fast as Go (Go+'s main backend compiles to human-readable Go).
 * Fully compatible with [Go](https://github.com/golang/go) and can mix Go/Go+ code in the same package (see [Go/Go+ hybrid programming](https://github.com/goplus/gop/blob/main/doc/docs.md#gogo-hybrid-programming)).
-* No DSL (Domain Specific Language) support, but it's Specific Domain Friendly (see [DSL vs. SDF](https://github.com/goplus/gop/blob/main/doc/dsl-vs-sdf.md)).
+* No DSL (Domain Specific Language) support, but SDF ([Specific Domain Friendliness](https://github.com/goplus/gop/blob/main/doc/classfile.md)).
 * Support Go code generation (main backend) and [bytecode backend](https://github.com/goplus/igop) (REPL: see [iGo+](https://repl.goplus.org/)).
 * [Simplest way to interaction with C](https://github.com/goplus/gop/blob/main/doc/docs.md#calling-c-from-go) (cgo is supported but not recommended).
 * [Powerful built-in data processing capabilities](https://github.com/goplus/gop/blob/main/doc/docs.md#data-processing).


### PR DESCRIPTION
Sync doc change from [key-features-of-go](https://github.com/goplus/gop/blob/main/README.md#key-features-of-go) and fix broken links as we mentioned in https://github.com/goplus/gop/issues/1771#issuecomment-1960590516