### PR TITLE
fix(CodeEditor): prevent scrolling beyond the last line

### DIFF
--- a/goplus.org/components/Code/Editor/index.tsx
+++ b/goplus.org/components/Code/Editor/index.tsx
@@ -27,6 +27,7 @@ function getMonacoOptions(isMobile: boolean) {
       horizontalScrollbarSize: scrollbarSize,
       verticalScrollbarSize: scrollbarSize
     },
+    scrollBeyondLastLine: false,
     overviewRulerLanes: 0
   }
   return monacoOptions


### PR DESCRIPTION
I'm not sure if this behavior is intentional, but allowing scrolling beyond the last line in the CodeEditor on the goplus.org homepage seems like a bug rather than a feature. It doesn't make sense for this specific use case. We should disable it unless it's somehow necessary.

---

<img width="1072" alt="Screenshot 2024-03-27 at 14 51 56" src="https://github.com/goplus/www/assets/5037285/6009f84d-6b14-46da-a4e2-c3b5d696bb52">
