### PR TITLE
fix(playground/sandbox): clear go.mod for auto-population by `go mod tidy`

### DIFF
--- a/playground/sandbox.go
+++ b/playground/sandbox.go
@@ -455,8 +455,6 @@ module playgrounddemo
 
 go 1.19
 
-require github.com/goplus/gop main
-
 `), 0644)
 
 	dumyCmd := exec.Command("mkdir", filepath.Join(tmpDir, "dummy"))


### PR DESCRIPTION
Removed invalid declaration `require github.com/goplus/gop main` which uses incorrect version syntax. Let `go mod tidy` automatically determine and manage the correct dependencies with proper version constraints.